### PR TITLE
[fix] proper function name: requestShopInterfaceAPI

### DIFF
--- a/copy_this/modules/fcoxid2afterbuy/core/fco2aorder.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2aorder.php
@@ -33,7 +33,7 @@ class fco2aorder extends fco2abase {
         $aConfig = $this->_fcGetAfterbuyConfigArray();
         $oAfterbuyApi = $this->_fcGetAfterbuyApi($aConfig);
 
-        $sOutput = $oAfterbuyApi->fcRequestShopInterfaceAPI($sRequest);
+        $sOutput = $oAfterbuyApi->requestShopInterfaceAPI($sRequest);
         $this->fcWriteLog("DEBUG: Requesting shopinterface for sending order:\n".$sRequest,4);
         $this->fcWriteLog("DEBUG: Response:\n".$sOutput,4);
         $this->_fcHandleShopInterfaceAnswer($sOutput, $oOrder);


### PR DESCRIPTION
changed "fcRequestShopInterfaceAPI" to "requestShopInterfaceAPI"

I have finally found this function in lib/fcafterbuyapi.php.
With this fix live order transfer to afterbuy works