### PR TITLE
proper product price for article export

### DIFF
--- a/copy_this/modules/fcoxid2afterbuy/core/fco2aartexport.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2aartexport.php
@@ -17,6 +17,7 @@ class fco2aartexport extends fco2abase {
         'AuctionQuantity' => 'oxarticles__oxstock|oxarticles__oxvarstock',
         'UnitOfQuantity' => 'oxarticles__oxunitname',
         'BuyingPrice' => 'oxarticles__oxbprice',
+        'SellingPrice' => 'oxarticles__oxprice',
         'Weight' => 'oxarticles__oxweight',
         'ShortDescription' => 'oxarticles__oxshortdesc',
     );
@@ -125,7 +126,6 @@ class fco2aartexport extends fco2abase {
      */
     protected function _fcAddArticleValues($oAfterbuyArticle, $oArticle) {
         $oAfterbuyArticle->Description = $oArticle->getLongDesc();
-        $oAfterbuyArticle->SellingPrice = $oArticle->getPrice()->getBruttoPrice();
         $oAfterbuyArticle->TaxRate = $oArticle->getArticleVat();
         $oAfterbuyArticle->ItemSize = $oArticle->getSize();
         $oAfterbuyArticle->CanonicalUrl = $oArticle->getMainLink();


### PR DESCRIPTION
$oArticle->getPrice() returns user specific price (A, B or C) including discounts, 
Also afterbuy api expects "german float" as datatype for prices... *facepalm
correct float like 19.99 becomes 1999,00 in afterbuy so you have to send prices with coma as decimal separator.
Therefore you need to change fcafterbuyapi.php in your private repository and add str_replace:
row 331: ````<SellingPrice>' . str_replace('.',',',$oArt->SellingPrice) . '</SellingPrice>````
row 340: ````<BuyingPrice>'.str_replace('.',',',$oArt->BuyingPrice).'</BuyingPrice>````