### PR TITLE
default pictures added to export

### DIFF
--- a/copy_this/modules/fcoxid2afterbuy/core/fco2aartexport.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2aartexport.php
@@ -147,6 +147,10 @@ class fco2aartexport extends fco2abase {
         }
 
         // pictures
+        $oAfterbuyArticle->ImageSmallURL = $oArticle->getThumbnailUrl(true);
+        $oAfterbuyArticle->ImageLargeURL = $oArticle->getZoomPictureUrl(1);
+
+        // gallery
         for($iIndex=1;$iIndex<=12;$iIndex++) {
             $sVarName_PicNr = "ProductPicture_Nr_".$iIndex;
             $sVarName_PicUrl = "ProductPicture_Url_".$iIndex;

--- a/copy_this/modules/fcoxid2afterbuy/core/fco2aartexport.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2aartexport.php
@@ -151,14 +151,18 @@ class fco2aartexport extends fco2abase {
         $oAfterbuyArticle->ImageLargeURL = $oArticle->getZoomPictureUrl(1);
 
         // gallery
+        $iPicNr = 1;
         for($iIndex=1;$iIndex<=12;$iIndex++) {
-            $sVarName_PicNr = "ProductPicture_Nr_".$iIndex;
-            $sVarName_PicUrl = "ProductPicture_Url_".$iIndex;
-            $sVarName_PicAltText = "ProductPicture_AltText_".$iIndex;
+            if(!$oArticle->getFieldData("oxpic{$iIndex}")) continue; // no picture set, skip.
+            
+            $sVarName_PicNr = "ProductPicture_Nr_".$iPicNr;
+            $sVarName_PicUrl = "ProductPicture_Url_".$iPicNr;
+            $sVarName_PicAltText = "ProductPicture_AltText_".$iPicNr;
 
-            $oAfterbuyArticle->$sVarName_PicNr = $iIndex;
+            $oAfterbuyArticle->$sVarName_PicNr = $iPicNr;
             $oAfterbuyArticle->$sVarName_PicUrl = $oArticle->getPictureUrl($iIndex);
             $oAfterbuyArticle->$sVarName_PicAltText = $oArticle->oxarticles__oxtitle->value;
+            $iPicNr++;
         }
 
         return $oAfterbuyArticle;


### PR DESCRIPTION
and fixed picture gallery export:
the original version iterates over all 12 oxpic fields and uses getPictureUrl() for getting it's url, but this function returns placeholder picture nopic.jpg if there is no picture in particular field.
This ways you always get picture gallery with 1-2 real pipctures and 10-11 nopic.jpc placeholders in afterbuy.