### PR TITLE
make fcafterbuyapi, fcafterbuyart and fcafterbuyorder extendable with modules

### DIFF
--- a/copy_this/modules/fcoxid2afterbuy/core/fco2abase.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2abase.php
@@ -143,11 +143,7 @@ class fco2abase extends oxBase {
      * @return object
      */
     protected function _fcGetAfterbuyOrder() {
-        $oViewConfig = oxRegistry::get('oxViewConfig');
-        $sPathToModule = $oViewConfig->getModulePath('fcoxid2afterbuy');
-        $sPathToAfterbuyLib = $sPathToModule.'lib/fcafterbuyorder.php';
-        include_once($sPathToAfterbuyLib);
-        $oAfterbuyOrder = new fcafterbuyorder();
+        $oAfterbuyOrder = oxNew("fcafterbuyorder");
 
         return $oAfterbuyOrder;
     }
@@ -159,11 +155,7 @@ class fco2abase extends oxBase {
      * @return object fcafterbuyart
      */
     protected function _fcGetAfterbuyArticle() {
-        $oViewConfig = oxRegistry::get('oxViewConfig');
-        $sPathToModule = $oViewConfig->getModulePath('fcoxid2afterbuy');
-        $sPathToAfterbuyLib = $sPathToModule.'lib/fcafterbuyapi.php';
-        include_once($sPathToAfterbuyLib);
-        $oAfterbuyArticle = new fcafterbuyart();
+        $oAfterbuyArticle = oxNew("fcafterbuyart");
 
         return $oAfterbuyArticle;
     }

--- a/copy_this/modules/fcoxid2afterbuy/core/fco2abase.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2abase.php
@@ -113,11 +113,7 @@ class fco2abase extends oxBase {
      */
     protected function _fcGetAfterbuyApi($aConfig) {
         $oViewConfig = oxRegistry::get('oxViewConfig');
-        $sPathToModule = $oViewConfig->getModulePath('fcoxid2afterbuy');
-        $sPathToAfterbuyLib = $sPathToModule.'lib/fcafterbuyapi.php';
-        include_once($sPathToAfterbuyLib);
-        $oAfterbuyApi = new fcafterbuyapi($aConfig);
-
+        $oAfterbuyApi = oxNew("fcafterbuyapi",$aConfig);
         // directly set oxid logfilepath after instantiation
         $oAfterbuyApi->setLogFilePath(getShopBasePath()."/log/fco2a_api.log");
 

--- a/copy_this/modules/fcoxid2afterbuy/core/fco2abase.php
+++ b/copy_this/modules/fcoxid2afterbuy/core/fco2abase.php
@@ -112,8 +112,8 @@ class fco2abase extends oxBase {
      * @return object
      */
     protected function _fcGetAfterbuyApi($aConfig) {
-        $oViewConfig = oxRegistry::get('oxViewConfig');
         $oAfterbuyApi = oxNew("fcafterbuyapi",$aConfig);
+        
         // directly set oxid logfilepath after instantiation
         $oAfterbuyApi->setLogFilePath(getShopBasePath()."/log/fco2a_api.log");
 

--- a/copy_this/modules/fcoxid2afterbuy/metadata.php
+++ b/copy_this/modules/fcoxid2afterbuy/metadata.php
@@ -43,6 +43,7 @@ $aModule = array(
         //core
         'fcafterbuyapi'          => 'fcoxid2afterbuy/lib/fcafterbuyapi.php',
         'fcafterbuyart'          => 'fcoxid2afterbuy/lib/fcafterbuyart.php',
+        'fcafterbuyorder'        => 'fcoxid2afterbuy/lib/fcafterbuyorder.php',
         'fcafterbuyorderstatus'  => 'fcoxid2afterbuy/lib/fcafterbuyorderstatus.php',
         'fco2abase'              => 'fcoxid2afterbuy/core/fco2abase.php',
         'fco2aorder'             => 'fcoxid2afterbuy/core/fco2aorder.php',


### PR DESCRIPTION
since ``fcafterbuyapi`` is registered in metadata.php ( line 44 ) you do not need to manually include fcafterbuyapi.php.
And by using oxid's ``oxNew()`` instead of regular ``new fcafterbuyapi()`` you can make fcafterbuyapi extendable with modules and provide easy customisation possibilities without changing module's code.
Same applies to fcafterbuyart, but i had to add fcafterbuyorder to metadata.php